### PR TITLE
Small fix in the plugin

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/config/ConfigEntry.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/config/ConfigEntry.java
@@ -44,7 +44,7 @@ public enum ConfigEntry
     SERVER_PERMBAN_URL(String.class, "server.permban_url"),
     //
     ADMINLIST_CLEAN_THESHOLD_HOURS(Integer.class, "adminlist.clean_threshold_hours"),
-    ADMINLIST_CONSOLE_RANK(Boolean.class, "adminlist.console_rank"),
+    ADMINLIST_CONSOLE_RANK(String.class, "adminlist.console_rank"),
     //
     DISABLE_NIGHT(Boolean.class, "disable.night"),
     DISABLE_WEATHER(Boolean.class, "disable.weather"),


### PR DESCRIPTION
If defining Console rank as string then it has to be defined as `String.class`
